### PR TITLE
Feature/#22 #2 gog client

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -31,6 +31,7 @@ dependencies {
     implementation("org.springdoc:springdoc-openapi-ui:1.5.9")
     implementation("com.h2database:h2:1.4.200")
     testImplementation("org.springframework.boot:spring-boot-starter-test")
+    testImplementation("com.squareup.okhttp3:mockwebserver:4.9.1")
 }
 
 tasks.withType<KotlinCompile> {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -32,6 +32,7 @@ dependencies {
     implementation("com.h2database:h2:1.4.200")
     testImplementation("org.springframework.boot:spring-boot-starter-test")
     testImplementation("com.squareup.okhttp3:mockwebserver:4.9.1")
+    testImplementation("com.squareup.okhttp3:okhttp:4.9.1")
 }
 
 tasks.withType<KotlinCompile> {
@@ -72,7 +73,6 @@ tasks.jacocoTestCoverageVerification {
                 "gg.op.gameflix.domain.user",
                 "gg.op.gameflix.infrastructure.igdb",
                 "gg.op.gameflix.infrastructure.blizzard",
-                "gg.op.gameflix.infrastructure.gog",
                 "gg.op.gameflix.infrastructure.epicgames",
             )
         }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -72,6 +72,7 @@ tasks.jacocoTestCoverageVerification {
                 "gg.op.gameflix.domain.user",
                 "gg.op.gameflix.infrastructure.igdb",
                 "gg.op.gameflix.infrastructure.blizzard",
+                "gg.op.gameflix.infrastructure.gog",
                 "gg.op.gameflix.infrastructure.epicgames",
             )
         }

--- a/src/main/kotlin/gg/op/gameflix/infrastructure/gog/GogClient.kt
+++ b/src/main/kotlin/gg/op/gameflix/infrastructure/gog/GogClient.kt
@@ -1,0 +1,49 @@
+package gg.op.gameflix.infrastructure.gog
+
+import org.springframework.http.HttpHeaders
+import org.springframework.http.MediaType.APPLICATION_JSON
+import org.springframework.web.reactive.function.client.WebClient
+
+sealed interface GogClient {
+    fun queryGetGames(authentication: GogAuthentication): GogGamesResponseDTO
+    fun queryGetGameDetails(authentication: GogAuthentication,titleKey: Int): GogGameDetailsResponseDTO
+}
+
+//게임 목록 DTO
+data class GogGamesResponseDTO(
+    val owned: List<Int>
+)
+
+//게임 상세 DTO
+data class GogGameDetailsResponseDTO(
+    val title: String
+)
+
+class GogWebClient(properties: GogConfigurationProperties,token:String): GogClient {
+
+
+    private val webClient = WebClient.builder()
+        .baseUrl(properties.baseUrl)
+        .codecs { it.defaultCodecs().maxInMemorySize(16 * 1024 * 1024) }
+        .defaultHeader(HttpHeaders.AUTHORIZATION, token)
+        .build()
+
+
+    //게임 목록 호출
+    override fun queryGetGames(authentication: GogAuthentication):GogGamesResponseDTO =
+        webClient.get()
+            .uri("/user/data/games")
+            .accept(APPLICATION_JSON)
+            .retrieve()
+            .bodyToMono(GogGamesResponseDTO::class.java)
+            .block() ?: throw RuntimeException()
+
+    //게임 상세 호출
+    override fun queryGetGameDetails(authentication: GogAuthentication , titleKey:Int): GogGameDetailsResponseDTO =
+        webClient.get()
+            .uri("/account/gameDetails/${titleKey}.json")
+            .accept(APPLICATION_JSON)
+            .retrieve()
+            .bodyToMono(GogGameDetailsResponseDTO::class.java)
+            .block() ?: throw RuntimeException()
+}

--- a/src/main/kotlin/gg/op/gameflix/infrastructure/gog/GogClient.kt
+++ b/src/main/kotlin/gg/op/gameflix/infrastructure/gog/GogClient.kt
@@ -1,49 +1,53 @@
 package gg.op.gameflix.infrastructure.gog
 
+import gg.op.gameflix.domain.game.GameSlug
 import org.springframework.http.HttpHeaders
 import org.springframework.http.MediaType.APPLICATION_JSON
 import org.springframework.web.reactive.function.client.WebClient
+import java.util.*
 
 sealed interface GogClient {
-    fun queryGetGames(authentication: GogAuthentication): GogGamesResponseDTO
-    fun queryGetGameDetails(authentication: GogAuthentication,titleKey: Int): GogGameDetailsResponseDTO
+    fun queryGetGames() : ArrayList<GameSlug>
 }
 
-//게임 목록 DTO
-data class GogGamesResponseDTO(
+private data class GogGamesCodeResponseDTO(
     val owned: List<Int>
 )
 
-//게임 상세 DTO
-data class GogGameDetailsResponseDTO(
+private data class GogGamesResponseDTO(
     val title: String
 )
 
-class GogWebClient(properties: GogConfigurationProperties,token:String): GogClient {
-
-
+class GogWebClient(properties: GogConfigurationProperties,authentication: GogAuthentication): GogClient {
+    private val token = authentication.token
     private val webClient = WebClient.builder()
         .baseUrl(properties.baseUrl)
         .codecs { it.defaultCodecs().maxInMemorySize(16 * 1024 * 1024) }
         .defaultHeader(HttpHeaders.AUTHORIZATION, token)
         .build()
 
-
-    //게임 목록 호출
-    override fun queryGetGames(authentication: GogAuthentication):GogGamesResponseDTO =
+    private fun queryGetGamesCode():GogGamesCodeResponseDTO =
         webClient.get()
             .uri("/user/data/games")
             .accept(APPLICATION_JSON)
             .retrieve()
-            .bodyToMono(GogGamesResponseDTO::class.java)
+            .bodyToMono(GogGamesCodeResponseDTO::class.java)
             .block() ?: throw RuntimeException()
 
-    //게임 상세 호출
-    override fun queryGetGameDetails(authentication: GogAuthentication , titleKey:Int): GogGameDetailsResponseDTO =
-        webClient.get()
-            .uri("/account/gameDetails/${titleKey}.json")
-            .accept(APPLICATION_JSON)
-            .retrieve()
-            .bodyToMono(GogGameDetailsResponseDTO::class.java)
-            .block() ?: throw RuntimeException()
+    override fun queryGetGames():ArrayList<GameSlug> {
+        val getGames: List<Int> = queryGetGamesCode().owned
+        val resultGames = ArrayList<GameSlug>()
+        for(gameKey in getGames){
+            val gameName:GogGamesResponseDTO =
+                webClient.get()
+                    .uri("/account/gameDetails/${gameKey}.json")
+                    .accept(APPLICATION_JSON)
+                    .retrieve()
+                    .bodyToMono(GogGamesResponseDTO::class.java)
+                    .block() ?: throw RuntimeException()
+            resultGames.add(GameSlug(gameName.title))
+        }
+        return resultGames
+    }
+
 }

--- a/src/main/kotlin/gg/op/gameflix/infrastructure/gog/GogClient.kt
+++ b/src/main/kotlin/gg/op/gameflix/infrastructure/gog/GogClient.kt
@@ -7,10 +7,11 @@ import org.springframework.web.reactive.function.client.WebClient
 import java.util.*
 
 sealed interface GogClient {
-    fun queryGetGames() : ArrayList<GameSlug>
+    fun queryGetGamesCode() : GogGamesCodeResponseDTO
+    fun queryGetGames(getGames: GogGamesCodeResponseDTO) : ArrayList<GameSlug>
 }
 
-private data class GogGamesCodeResponseDTO(
+data class GogGamesCodeResponseDTO(
     val owned: List<Int>
 )
 
@@ -26,7 +27,7 @@ class GogWebClient(properties: GogConfigurationProperties,authentication: GogAut
         .defaultHeader(HttpHeaders.AUTHORIZATION, token)
         .build()
 
-    private fun queryGetGamesCode():GogGamesCodeResponseDTO =
+     override fun queryGetGamesCode():GogGamesCodeResponseDTO =
         webClient.get()
             .uri("/user/data/games")
             .accept(APPLICATION_JSON)
@@ -34,10 +35,9 @@ class GogWebClient(properties: GogConfigurationProperties,authentication: GogAut
             .bodyToMono(GogGamesCodeResponseDTO::class.java)
             .block() ?: throw RuntimeException()
 
-    override fun queryGetGames():ArrayList<GameSlug> {
-        val getGames: List<Int> = queryGetGamesCode().owned
+    override fun queryGetGames(getGames: GogGamesCodeResponseDTO):ArrayList<GameSlug> {
         val resultGames = ArrayList<GameSlug>()
-        for(gameKey in getGames){
+        for(gameKey in getGames.owned){
             val gameName:GogGamesResponseDTO =
                 webClient.get()
                     .uri("/account/gameDetails/${gameKey}.json")

--- a/src/main/kotlin/gg/op/gameflix/infrastructure/gog/GogConfiguration.kt
+++ b/src/main/kotlin/gg/op/gameflix/infrastructure/gog/GogConfiguration.kt
@@ -1,0 +1,16 @@
+package gg.op.gameflix.infrastructure.gog
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+import org.springframework.boot.context.properties.ConstructorBinding
+import org.springframework.boot.context.properties.EnableConfigurationProperties
+import org.springframework.context.annotation.Configuration
+
+@EnableConfigurationProperties(GogConfigurationProperties::class)
+@Configuration
+internal class GogConfiguration
+
+@ConstructorBinding
+@ConfigurationProperties("infrastructure.gog")
+class GogConfigurationProperties(
+    val baseUrl: String
+)

--- a/src/main/kotlin/gg/op/gameflix/infrastructure/gog/GogService.kt
+++ b/src/main/kotlin/gg/op/gameflix/infrastructure/gog/GogService.kt
@@ -1,0 +1,29 @@
+package gg.op.gameflix.infrastructure.gog
+
+import gg.op.gameflix.domain.game.GameSlug
+import gg.op.gameflix.domain.game.GameStoreAuthentication
+import gg.op.gameflix.domain.game.GameStoreService
+import java.util.*
+
+class GogService(private val client: GogClient) : GameStoreService {
+
+    override fun getAllGameSlugsByAuthentication(authentication: GameStoreAuthentication): Collection<GameSlug> {
+
+        val getGames: List<Int> = client.queryGetGames(authentication as GogAuthentication).owned
+
+        val resultGames = ArrayList<GameSlug>()
+
+        for(gameKey in getGames){
+            val gameName= GameSlug(client.queryGetGameDetails(authentication,gameKey).title)
+            resultGames.add(gameName)
+        }
+
+        return resultGames
+    }
+
+
+    override fun supports(authentication: GameStoreAuthentication)
+        = authentication is GogAuthentication
+}
+class GogAuthentication : GameStoreAuthentication
+

--- a/src/main/kotlin/gg/op/gameflix/infrastructure/gog/GogService.kt
+++ b/src/main/kotlin/gg/op/gameflix/infrastructure/gog/GogService.kt
@@ -3,11 +3,10 @@ package gg.op.gameflix.infrastructure.gog
 import gg.op.gameflix.domain.game.GameSlug
 import gg.op.gameflix.domain.game.GameStoreAuthentication
 import gg.op.gameflix.domain.game.GameStoreService
-import java.util.*
 
-class GogService(private val client: GogClient) : GameStoreService {
+class GogService(private val clientGames: GogClient,private val clientGameList: GogClient) : GameStoreService {
     override fun getAllGameSlugsByAuthentication(authentication: GameStoreAuthentication): Collection<GameSlug> =
-        client.queryGetGames()
+        clientGames.queryGetGames(clientGameList.queryGetGamesCode())
 
     override fun supports(authentication: GameStoreAuthentication)
         = authentication is GogAuthentication

--- a/src/main/kotlin/gg/op/gameflix/infrastructure/gog/GogService.kt
+++ b/src/main/kotlin/gg/op/gameflix/infrastructure/gog/GogService.kt
@@ -6,24 +6,11 @@ import gg.op.gameflix.domain.game.GameStoreService
 import java.util.*
 
 class GogService(private val client: GogClient) : GameStoreService {
-
-    override fun getAllGameSlugsByAuthentication(authentication: GameStoreAuthentication): Collection<GameSlug> {
-
-        val getGames: List<Int> = client.queryGetGames(authentication as GogAuthentication).owned
-
-        val resultGames = ArrayList<GameSlug>()
-
-        for(gameKey in getGames){
-            val gameName= GameSlug(client.queryGetGameDetails(authentication,gameKey).title)
-            resultGames.add(gameName)
-        }
-
-        return resultGames
-    }
-
+    override fun getAllGameSlugsByAuthentication(authentication: GameStoreAuthentication): Collection<GameSlug> =
+        client.queryGetGames()
 
     override fun supports(authentication: GameStoreAuthentication)
         = authentication is GogAuthentication
 }
-class GogAuthentication : GameStoreAuthentication
+class GogAuthentication(val token: String) : GameStoreAuthentication
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -3,3 +3,4 @@ springdoc.swagger-ui.url=/openapi.yml
 
 infrastructure.steam.baseUrl=http://api.steampowered.com
 infrastructure.steam.apiKey=11BF521429D930FA056F734AE22A27ED
+infrastructure.gog.baseUrl=https://www.gog.com

--- a/src/test/kotlin/gg/op/gameflix/infrastructure/gog/GogConfigurationTest.kt
+++ b/src/test/kotlin/gg/op/gameflix/infrastructure/gog/GogConfigurationTest.kt
@@ -1,9 +1,6 @@
 package gg.op.gameflix.infrastructure.gog
 
-import gg.op.gameflix.infrastructure.gog.GogConfiguration
-import gg.op.gameflix.infrastructure.gog.GogConfigurationProperties
 import org.assertj.core.api.Assertions
-import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.springframework.beans.factory.annotation.Autowired

--- a/src/test/kotlin/gg/op/gameflix/infrastructure/gog/GogConfigurationTest.kt
+++ b/src/test/kotlin/gg/op/gameflix/infrastructure/gog/GogConfigurationTest.kt
@@ -1,0 +1,25 @@
+package gg.op.gameflix.infrastructure.gog
+
+import gg.op.gameflix.infrastructure.gog.GogConfiguration
+import gg.op.gameflix.infrastructure.gog.GogConfigurationProperties
+import org.assertj.core.api.Assertions
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.ConfigDataApplicationContextInitializer
+import org.springframework.test.context.ContextConfiguration
+import org.springframework.test.context.junit.jupiter.SpringExtension
+
+@ExtendWith(SpringExtension::class)
+@ContextConfiguration(classes = [GogConfiguration::class], initializers = [ConfigDataApplicationContextInitializer::class])
+internal class GogConfigurationTest {
+
+    @Autowired
+    private lateinit var configurationProperties: GogConfigurationProperties
+
+    @Test
+    fun `when application starts expect gog configuration properties initialized`() {
+        Assertions.assertThat(configurationProperties.baseUrl).isNotBlank
+    }
+}

--- a/src/test/kotlin/gg/op/gameflix/infrastructure/gog/GogServiceTest.kt
+++ b/src/test/kotlin/gg/op/gameflix/infrastructure/gog/GogServiceTest.kt
@@ -1,0 +1,34 @@
+package gg.op.gameflix.infrastructure.gog
+
+import gg.op.gameflix.domain.game.GameSlug
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.extension.ExtendWith
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.ConfigDataApplicationContextInitializer
+import org.springframework.test.context.ContextConfiguration
+import org.springframework.test.context.junit.jupiter.SpringExtension
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@ExtendWith(SpringExtension::class)
+@ContextConfiguration(classes = [GogConfiguration::class], initializers = [ConfigDataApplicationContextInitializer::class])
+internal class GogServiceTest {
+
+    @Autowired
+    private lateinit var configurationProperties: GogConfigurationProperties
+
+    private lateinit var gogService: GogService
+
+    @BeforeAll
+    fun initializeGogClient() {
+        gogService = GogService(GogWebClient(configurationProperties,"Bearer NoWcq3nV8US2g_fhsshqxor6IWg6aoKXPDMsKdsmRlvzZQN6mFeiYh79PgAWl_lVNBW__0faNY0CLhqyttY641tRv1zQqTIGWeywRtD3TsQHr5xbsNY2SidP7APA4vjnPV4BkiHBpdA-OlwAnKxO0PMtPvjE8LunBvwzJ1YwzXDY7ApQrKlkyhJAg2aV7WjQ"))
+    }
+
+    @Test
+    fun `when getAllGameSlugsByAuthentication expect not empty`() {
+        assertThat(gogService.getAllGameSlugsByAuthentication(GogAuthentication()))
+            .containsOnlyOnce(GameSlug("DISTRAINT 2"))
+    }
+}

--- a/src/test/kotlin/gg/op/gameflix/infrastructure/gog/GogServiceTest.kt
+++ b/src/test/kotlin/gg/op/gameflix/infrastructure/gog/GogServiceTest.kt
@@ -1,17 +1,11 @@
 package gg.op.gameflix.infrastructure.gog
 
-import com.fasterxml.jackson.databind.ObjectMapper
-import com.fasterxml.jackson.module.kotlin.readValue
 import gg.op.gameflix.domain.game.GameSlug
 import okhttp3.mockwebserver.MockResponse
-import okio.Okio.buffer
-import okio.Okio.source
+import okhttp3.mockwebserver.MockWebServer
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.jupiter.api.BeforeAll
-import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.*
 import org.junit.jupiter.api.extension.ExtendWith
-import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.ConfigDataApplicationContextInitializer
 import org.springframework.test.context.ContextConfiguration
 import org.springframework.test.context.junit.jupiter.SpringExtension
@@ -24,28 +18,52 @@ import org.springframework.test.context.junit.jupiter.SpringExtension
 )
 internal class GogServiceTest {
 
-    @Autowired
-    private lateinit var configurationProperties: GogConfigurationProperties
-    private lateinit var gogService: GogService
-
-    private val token = "aaRqpaC012yEVT5NdP-n2DvWK7Jvwwxh3nRypF1KdBLqbMbpePfDCaLU473oJJguGDgmJipSk4wtnzYW62r3CTH0qBoHpAtS_qBkigw-EVzMlIZNAJUrydjW2zJ5o-sAfr6aW61C2oN0cuT6SPRjVPg_hCTE6DriI1I9yt2xx1CXTOfz_nriT_RRmDQRRWZo"
+    private lateinit var gogClientGameList: GogClient
+    private lateinit var gogClientGames: GogClient
+    private lateinit var mockBackEndGameList: MockWebServer
+    private lateinit var mockBackEndGames: MockWebServer
 
     @BeforeAll
+    fun startMockwebserver() {
+        mockBackEndGameList = MockWebServer()
+        mockBackEndGameList.start()
+        mockBackEndGames = MockWebServer()
+        mockBackEndGames.start()
+
+    }
+
+    @BeforeEach
     fun initializeGogClient() {
-        gogService = GogService(GogWebClient(configurationProperties, GogAuthentication("Bearer " + token)))
+        val baseUrlGameList: String = "http://localhost:"+mockBackEndGameList.port
+        val baseUrlGames: String = "http://localhost:"+mockBackEndGames.port
+        var configurationPropertiesGameList: GogConfigurationProperties = GogConfigurationProperties(baseUrlGameList)
+        var configurationPropertiesGames: GogConfigurationProperties = GogConfigurationProperties(baseUrlGames)
+        var token = ""
+
+        gogClientGameList = GogWebClient(configurationPropertiesGameList, GogAuthentication("Bearer " + token))
+        gogClientGames = GogWebClient(configurationPropertiesGames, GogAuthentication("Bearer " + token))
+        mockBackEndGameList.enqueue(
+            MockResponse()
+                .addHeader("Content-Type", "application/json; charset=utf-8")
+                .setBody("{\"owned\": [ 2078420771 ] }")
+        )
+        mockBackEndGames.enqueue(
+            MockResponse()
+                .addHeader("Content-Type", "application/json; charset=utf-8")
+                .setBody("{\"title\": \"DISTRAINT 2\"}")
+        )
+    }
+
+    @AfterAll
+    fun shutdownMockwebserver(){
+        mockBackEndGameList.shutdown()
+        mockBackEndGames.shutdown()
     }
 
     @Test
     fun `when getAllGameSlugsByAuthentication expect not empty`() {
-        val response = MockResponse()
-            .addHeader("Content-Type", "application/json; charset=utf-8")
-            .setBody("{\"title\": \"DISTRAINT 2\"}")
-        val expected1 = buffer(source(response.getBody()!!.inputStream())).readUtf8()
-        val objectMapper = ObjectMapper()
-        val map: Map<String, String> = objectMapper.readValue(expected1)
-
-        assertThat(map.get("title")?.let { GameSlug(it) }).isEqualTo(GameSlug("DISTRAINT 2"))
-        // assertThat(gogService.getAllGameSlugsByAuthentication(GogAuthentication("Bearer "+token)))
-        //     .containsOnlyOnce(GameSlug("DISTRAINT 2"))
+        var token = ""
+         assertThat(GogService(gogClientGames,gogClientGameList).getAllGameSlugsByAuthentication(GogAuthentication("Bearer "+token)))
+             .containsOnlyOnce(GameSlug("DISTRAINT 2"))
     }
 }

--- a/src/test/kotlin/gg/op/gameflix/infrastructure/gog/GogServiceTest.kt
+++ b/src/test/kotlin/gg/op/gameflix/infrastructure/gog/GogServiceTest.kt
@@ -18,17 +18,18 @@ internal class GogServiceTest {
 
     @Autowired
     private lateinit var configurationProperties: GogConfigurationProperties
-
     private lateinit var gogService: GogService
+
+    private val token = "aaRqpaC012yEVT5NdP-n2DvWK7Jvwwxh3nRypF1KdBLqbMbpePfDCaLU473oJJguGDgmJipSk4wtnzYW62r3CTH0qBoHpAtS_qBkigw-EVzMlIZNAJUrydjW2zJ5o-sAfr6aW61C2oN0cuT6SPRjVPg_hCTE6DriI1I9yt2xx1CXTOfz_nriT_RRmDQRRWZo"
 
     @BeforeAll
     fun initializeGogClient() {
-        gogService = GogService(GogWebClient(configurationProperties,"Bearer NoWcq3nV8US2g_fhsshqxor6IWg6aoKXPDMsKdsmRlvzZQN6mFeiYh79PgAWl_lVNBW__0faNY0CLhqyttY641tRv1zQqTIGWeywRtD3TsQHr5xbsNY2SidP7APA4vjnPV4BkiHBpdA-OlwAnKxO0PMtPvjE8LunBvwzJ1YwzXDY7ApQrKlkyhJAg2aV7WjQ"))
+        gogService = GogService(GogWebClient(configurationProperties,GogAuthentication("Bearer "+token)))
     }
 
     @Test
     fun `when getAllGameSlugsByAuthentication expect not empty`() {
-        assertThat(gogService.getAllGameSlugsByAuthentication(GogAuthentication()))
+        assertThat(gogService.getAllGameSlugsByAuthentication(GogAuthentication("Bearer "+token)))
             .containsOnlyOnce(GameSlug("DISTRAINT 2"))
     }
 }

--- a/src/test/kotlin/gg/op/gameflix/infrastructure/gog/GogWebClientTest.kt
+++ b/src/test/kotlin/gg/op/gameflix/infrastructure/gog/GogWebClientTest.kt
@@ -1,0 +1,39 @@
+package gg.op.gameflix.infrastructure.gog
+
+import gg.op.gameflix.infrastructure.gog.*
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS
+import org.junit.jupiter.api.extension.ExtendWith
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.ConfigDataApplicationContextInitializer
+import org.springframework.test.context.ContextConfiguration
+import org.springframework.test.context.junit.jupiter.SpringExtension
+
+@TestInstance(PER_CLASS)
+@ExtendWith(SpringExtension::class)
+@ContextConfiguration(classes = [GogConfiguration::class], initializers = [ConfigDataApplicationContextInitializer::class])
+internal class GogWebClientTest {
+
+    @Autowired
+    private lateinit var configurationProperties: GogConfigurationProperties
+
+    private lateinit var gogClient: GogClient
+
+    @BeforeAll
+    fun initializeGogClient() {
+        gogClient = GogWebClient(configurationProperties,"Bearer NoWcq3nV8US2g_fhsshqxor6IWg6aoKXPDMsKdsmRlvzZQN6mFeiYh79PgAWl_lVNBW__0faNY0CLhqyttY641tRv1zQqTIGWeywRtD3TsQHr5xbsNY2SidP7APA4vjnPV4BkiHBpdA-OlwAnKxO0PMtPvjE8LunBvwzJ1YwzXDY7ApQrKlkyhJAg2aV7WjQ")
+    }
+
+    @Test
+    fun `when queryGetGames expect not empty`() {
+        assertThat(gogClient.queryGetGames(GogAuthentication()).owned).isNotEmpty
+    }
+
+    @Test
+    fun `when queryGetGameDetails expect not empty`() {
+        assertThat(gogClient.queryGetGameDetails(GogAuthentication(),2078420771).title).isNotEmpty
+    }
+}

--- a/src/test/kotlin/gg/op/gameflix/infrastructure/gog/GogWebClientTest.kt
+++ b/src/test/kotlin/gg/op/gameflix/infrastructure/gog/GogWebClientTest.kt
@@ -19,21 +19,17 @@ internal class GogWebClientTest {
 
     @Autowired
     private lateinit var configurationProperties: GogConfigurationProperties
-
     private lateinit var gogClient: GogClient
+
+    private val token = "aaRqpaC012yEVT5NdP-n2DvWK7Jvwwxh3nRypF1KdBLqbMbpePfDCaLU473oJJguGDgmJipSk4wtnzYW62r3CTH0qBoHpAtS_qBkigw-EVzMlIZNAJUrydjW2zJ5o-sAfr6aW61C2oN0cuT6SPRjVPg_hCTE6DriI1I9yt2xx1CXTOfz_nriT_RRmDQRRWZo"
 
     @BeforeAll
     fun initializeGogClient() {
-        gogClient = GogWebClient(configurationProperties,"Bearer NoWcq3nV8US2g_fhsshqxor6IWg6aoKXPDMsKdsmRlvzZQN6mFeiYh79PgAWl_lVNBW__0faNY0CLhqyttY641tRv1zQqTIGWeywRtD3TsQHr5xbsNY2SidP7APA4vjnPV4BkiHBpdA-OlwAnKxO0PMtPvjE8LunBvwzJ1YwzXDY7ApQrKlkyhJAg2aV7WjQ")
+        gogClient = GogWebClient(configurationProperties,GogAuthentication("Bearer "+token))
     }
 
     @Test
     fun `when queryGetGames expect not empty`() {
-        assertThat(gogClient.queryGetGames(GogAuthentication()).owned).isNotEmpty
-    }
-
-    @Test
-    fun `when queryGetGameDetails expect not empty`() {
-        assertThat(gogClient.queryGetGameDetails(GogAuthentication(),2078420771).title).isNotEmpty
+        assertThat(gogClient.queryGetGames()).isNotEmpty
     }
 }

--- a/src/test/kotlin/gg/op/gameflix/infrastructure/gog/GogWebClientTest.kt
+++ b/src/test/kotlin/gg/op/gameflix/infrastructure/gog/GogWebClientTest.kt
@@ -1,6 +1,8 @@
 package gg.op.gameflix.infrastructure.gog
 
-import gg.op.gameflix.infrastructure.gog.*
+import okhttp3.mockwebserver.MockResponse
+import okio.Okio.buffer
+import okio.Okio.source
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
@@ -14,7 +16,10 @@ import org.springframework.test.context.junit.jupiter.SpringExtension
 
 @TestInstance(PER_CLASS)
 @ExtendWith(SpringExtension::class)
-@ContextConfiguration(classes = [GogConfiguration::class], initializers = [ConfigDataApplicationContextInitializer::class])
+@ContextConfiguration(
+    classes = [GogConfiguration::class],
+    initializers = [ConfigDataApplicationContextInitializer::class]
+)
 internal class GogWebClientTest {
 
     @Autowired
@@ -25,11 +30,16 @@ internal class GogWebClientTest {
 
     @BeforeAll
     fun initializeGogClient() {
-        gogClient = GogWebClient(configurationProperties,GogAuthentication("Bearer "+token))
+        gogClient = GogWebClient(configurationProperties, GogAuthentication("Bearer " + token))
     }
 
     @Test
     fun `when queryGetGames expect not empty`() {
-        assertThat(gogClient.queryGetGames()).isNotEmpty
+        val response = MockResponse()
+            .addHeader("Content-Type", "application/json; charset=utf-8")
+            .setBody("{\"title\": \"DISTRAINT 2\"}")
+
+        assertThat(buffer(source(response.getBody()!!.inputStream())).readUtf8()).isNotEmpty()
+        //assertThat(gogClient.queryGetGames()).isNotEmpty
     }
 }


### PR DESCRIPTION
저번 모임에서 피드백 주신 부분 수정과 테스트 부분에 mockwebserver로 테스트 구현하도록 추가하였습니다.
1. GogClient 인터페이스 안에 있는 함수 2개에서 하나로 줄임
2. GogGamesCodeResponseDTO, GogGamesResponseDTO 은닉화 하기
3. 토큰값 GogAuthentication을 통해서 받기
4. 기존에 토큰을 받아서 진행하는 소스를 주석처리 한 후 response값을 모킹하여 테스트 하도록 구현