### PR TITLE
#33 Add arm architecture image in jib configuration

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -97,6 +97,10 @@ jib {
                 architecture = "amd64"
                 os = "linux"
             }
+            platform {
+                architecture = "arm64"
+                os = "linux"
+            }
         }
     }
     to {


### PR DESCRIPTION
m1 mac 에서 image 가 실행되지 않는 문제입니다. 
자세한 사항은 이슈 #33 을 확인해주세요

